### PR TITLE
fix #34: use correct error message

### DIFF
--- a/examples/Catena4430_Sensor/Catena4430_Sensor.ino
+++ b/examples/Catena4430_Sensor/Catena4430_Sensor.ino
@@ -39,7 +39,7 @@ static_assert(
     "This sketch requires Catena-Arduino-Platform v0.21.0-5 or later"
     );
 
-constexpr std::uint32_t kAppVersion = makeVersion(0,5,2,0);
+constexpr std::uint32_t kAppVersion = makeVersion(0,5,3,2);
 constexpr std::uint32_t kDoubleResetWaitMs = 500;
 constexpr std::uint32_t kSetDoubleResetMagic = 0xCA44301;
 constexpr std::uint32_t kClearDoubleResetMagic = 0xCA44300;

--- a/examples/Catena4430_Sensor/Catena4430_cMeasurementLoop.cpp
+++ b/examples/Catena4430_Sensor/Catena4430_cMeasurementLoop.cpp
@@ -283,7 +283,7 @@ cMeasurementLoop::fsmDispatch(
     case State::stAwaitCard:
         if (fEntry)
             {
-            gCatena.SafePrintf("** no SD card and not provisioned!\n");
+            gCatena.SafePrintf("** lorawan not provisioned!\n");
             }
 
         newState = State::stSleeping;

--- a/examples/Catena4430_Sensor/Catena4430_cMeasurementLoop_SDcard.cpp
+++ b/examples/Catena4430_Sensor/Catena4430_cMeasurementLoop_SDcard.cpp
@@ -142,13 +142,13 @@ cMeasurementLoop::writeSdCard(
 
     if (! mData.DateTime.isValid())
         {
-        gCatena.SafePrintf("measurement time not valid\n");
+        gCatena.SafePrintf("RTC not set, not storing data!\n");
         return false;
         }
 
     fResult = this->checkSdCard();
     if (! fResult)
-        gCatena.SafePrintf("checkSdCard() failed\n");
+        gCatena.SafePrintf("** SD card not detected!\n");
 
     if (fResult)
         {


### PR DESCRIPTION
Have modified the error messages to provide correct information, and followed the steps to reproduce the issue. Please find the log:

```
------------------------------------------------------------------------
This is Catena4430_Sensor.ino v0.5.2-0.
Target network: The Things Network / us915
System clock rate is 2.097 MHz
Enter 'help' for a list of commands.
------------------------------------------------------------------------

FLASH found, put power down
cMeasurementLoop::fsmDispatch: enter stInactive
RTC is not running
?CatenaStm32L0::LoRaWAN::begin: Arduino_LoRaWAN:begin failed
?Catena461x::LoRaWAN::begin: Super::begin() failed
cMeasurementLoop::fsmDispatch: enter stWarmup
cMeasurementLoop::fsmDispatch: enter stMeasure
cMeasurementLoop::fsmDispatch: enter stTransmit
Vbat:    4206 mV
Vbus:    5136 mV
BME280:  T: 28 P: 101184 RH: 39
Si1133:  644579 White
cMeasurementLoop::fsmDispatch: enter stWriteFile
RTC not set, not storing data!
cMeasurementLoop::fsmDispatch: enter stAwaitCard
** lorawan not provisioned!
cMeasurementLoop::fsmDispatch: enter stSleeping
using light sleep
dir
DATA/

OK
tree
DATA/
    20220203.DAT         25425
    20220210.DAT          5533
    20220215.DAT         32664
    20220216.DAT          7086
    20220217.DAT           316
    20220301.DAT           979

OK
```